### PR TITLE
Remove unused @atcute/bluesky package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 	],
 	"dependencies": {
 		"@atcute/atproto": "^3.1.0",
-		"@atcute/bluesky": "^3.1.4",
 		"@atcute/lexicons": "^1.1.0",
 		"partysocket": "^1.1.3",
 		"tiny-emitter": "^2.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@atcute/atproto':
         specifier: ^3.1.0
         version: 3.1.0
-      '@atcute/bluesky':
-        specifier: ^3.1.4
-        version: 3.1.4
       '@atcute/lexicons':
         specifier: ^1.1.0
         version: 1.1.0
@@ -54,9 +51,6 @@ packages:
 
   '@atcute/atproto@3.1.0':
     resolution: {integrity: sha512-aJbDsY7FcIh8APWKAimBtshPwqoRE056tc0UV6vw4TW4e3nYaHedoJmKhlh/k8KQWxyw64MQThNGMaC89HNoTg==}
-
-  '@atcute/bluesky@3.1.4':
-    resolution: {integrity: sha512-iSdZGk/UktgKpT/lI0/YxRjM3E5dkd6/vIa2mgH82lgRjI0jH5LJAfLXPyr2mPeZ/qku1gf2/KrkqJ9dfiNxVw==}
 
   '@atcute/client@4.0.3':
     resolution: {integrity: sha512-RIOZWFVLca/HiPAAUDqQPOdOreCxTbL5cb+WUf5yqQOKIu5yEAP3eksinmlLmgIrlr5qVOE7brazUUzaskFCfw==}
@@ -638,11 +632,6 @@ snapshots:
 
   '@atcute/atproto@3.1.0':
     dependencies:
-      '@atcute/lexicons': 1.1.0
-
-  '@atcute/bluesky@3.1.4':
-    dependencies:
-      '@atcute/atproto': 3.1.0
       '@atcute/lexicons': 1.1.0
 
   '@atcute/client@4.0.3':

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { ComAtprotoSyncSubscribeRepos } from "@atcute/atproto";
 import type { Cid, Did } from "@atcute/lexicons";
 import { Records as _Records } from "@atcute/lexicons/ambient";
-import "@atcute/bluesky/lexicons";
 import { WebSocket } from "partysocket";
 import { TinyEmitter } from "tiny-emitter";
 


### PR DESCRIPTION
I missed an unused dependency that also prevented the package from working when used, as "@atcute/bluesky/lexicons" was still trying to be imported despite not being an exported subpath of the package. Whoops!